### PR TITLE
Fix crash when users.json contains no users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 !*.dll
 !modules/
 !ChatServer/
+ChatServer/ChatServer/bin/*
+ChatServer/ChatServer/obj/*

--- a/chatManager.cs
+++ b/chatManager.cs
@@ -210,7 +210,10 @@ the actions of any user within the chat.".Replace("\n", " ");
          if (MySerialize.LoadObject<Dictionary<int, User>>(SavePath(UserFile), out tempUsers))
          {
             users = tempUsers;
-            UserSession.SetNextID(users.Max(x => x.Value.MaxSessionID) + 1);
+            if(users.Count > 0)
+            {
+                UserSession.SetNextID(users.Max(x => x.Value.MaxSessionID) + 1);
+            };
             Log("Loaded user data from file", MyExtensions.Logging.LogLevel.Debug);
          }
          else


### PR DESCRIPTION
This fixes the bug I was mentioning when serverdir/saves/users.json does not contain any users. It uses a simple check to see if the Users dictionary contains anything.
